### PR TITLE
proof of concept: @pika/turbo

### DIFF
--- a/@pika--turbo.js
+++ b/@pika--turbo.js
@@ -1,0 +1,39 @@
+const MANIFEST = {
+  "/index.js": [
+    "/web_modules/htm.js",
+    "/web_modules/csz/index.js",
+  ],
+  "/routes/home/index.js": [
+    '/components/tests.js',
+    '/components/results.js',
+  ],
+  "/components/tests.js": [
+    '/components/icons.js',
+    '/components/editor.js',
+  ],
+};
+
+const LOADED = new Set();
+window.turbo = {};
+window.turbo.preloadAll = function preloadAll() {
+  for (const script of document.querySelectorAll('script')) {
+    window.turbo.preload(script.src);
+  }
+}
+
+window.turbo.preload = function preload(url) {
+  const deps = MANIFEST[url];
+  if (!deps || LOADED.has(url)) {
+    return;
+  }
+  LOADED.add(url);
+  for (const dep of [url, ...deps]) {
+    const preloadLink = document.createElement("link");
+    preloadLink.rel = "modulepreload";
+    preloadLink.href = dep;
+    document.head.appendChild(preloadLink);
+  }
+  for (const dep of deps) {
+    preload(dep);
+  }
+}

--- a/index.html
+++ b/index.html
@@ -34,6 +34,11 @@
     <link rel="stylesheet" href="/index.css" />
     <link rel="stylesheet" href="/library/prism.css" />
     <link rel="stylesheet" href="/routes/home/index.css" />
+
+    <!-- TURBO MODE... ENGAGE! -->
+    <script src="/@pika--turbo.js"></script>
+    <script>window.turbo.preload('/index.js');</script>
+
     <script defer src="/library/prism.js"></script>
     <script type="module">
       import {app} from '/index.js';

--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ export function app({ React, ReactDOM }) {
     <div></div>
   `
   const Route = {
-    '/': React.lazy(() => import('./routes/home/index.js')),
-    '*': React.lazy(() => import('./routes/notfound/index.js')),
+    '/': React.lazy(() => window.turbo.preload('/routes/home/index.js') || import('/routes/home/index.js')),
+    '*': React.lazy(() => window.turbo.preload('/routes/notfound/index.js') || import('/routes/notfound/index.js')),
   }
 
   ReactDOM.render(


### PR DESCRIPTION
This is an experiment to follow up to: https://twitter.com/FredKSchott/status/1115439794358644736

**Problem:** It is possible to see long chains of serial imports when serving unbundled JS. This can be especially painful over slow networks, depending on how long the chain of imports is.
**Question:** While this is exactly where a bundler can help you, how could we solve this perf problem without bundling / adding a build step?
**Idea:** Build out a userland proof-of-concept for a solution that pre-calculates the import graph at deploy-time, so that the application author can automatically inject "modulepreload" link elements onto the page ahead of time.


### Potential Interface (Userland)

```html
<script type="module">
      import {preload} from '/pika-turbo.js';
      preload("index.js"); // Inject <link rel="modulepreload"> elements onto the page for all transitive dependencies
</script>
<script type="module" src="index.js"></script>
```

### Results (Before) ~3700ms

<img width="914" alt="Screen Shot 2019-04-11 at 11 17 52 PM" src="https://user-images.githubusercontent.com/622227/56016267-8b257c80-5cb0-11e9-81f6-22013df69e5b.png">

### Results (After) ~2800ms

<img width="918" alt="Screen Shot 2019-04-11 at 11 16 59 PM" src="https://user-images.githubusercontent.com/622227/56016272-8d87d680-5cb0-11e9-99b2-463563e94fd7.png">


### Problems With Actual Behavior

Once Chrome starts downloading "index.js" for its script element, the injected `<link>` elements don't actually affect the loading order of that dependency tree (even though they have been added to the page before the first file in the tree has finished loading). All "foobar.js" dependencies continue to load as discovered even though the look-ahead `<link rel="modulepreload">` elements already exist on the page. 

They are giving preload hints for files deeper in the tree, so waiting for the tree to be discovered does them no good.

```
1. Browser fetches turbo.js
2. Browser fetches application (index.js)
3. turbo.js returns, adds "modulepreload" elements to the page for every dep of application

Desired Behavior
4. Browser immediately queues up every "modulepreload" for loading in parallel with application

Actual Behavior
4. Browser does not queue those up until the application tree is done being discovered & loaded

```

### Userland Workaround (Temporary... hopefully)

```html
<script src="/@pika--turbo.js"></script>
<script>window.turbo.preload('foobar.js');</script>
<script type="module" src="foobar.js"></script>
```

Yes, this does block the rest of the page from executing, so that all `<link rel="modulepreload">` 
 elements are injected onto the page before "foobar.js" is kicked off. It is still better performance-wise for large trees, but the blocking + the AMD interface are unfortunate and may be too hard to stomach for some.